### PR TITLE
Refactor settings rendering helper

### DIFF
--- a/app.js
+++ b/app.js
@@ -181,10 +181,16 @@
   };
 
   // Settings form
+  const renderSettingsForm = () => {
+    if (!STATE.settings) STATE.settings = defaultState().settings;
+    const settings = STATE.settings;
+    $("#startDate").value = settings.startDate || todayYMD;
+    $("#endDate").value = settings.endDate || defaultEnd;
+    $("#startingBalance").value = Number(settings.startingBalance || 0);
+  };
+
   const initSettings = () => {
-    $("#startDate").value = STATE.settings.startDate;
-    $("#endDate").value = STATE.settings.endDate || defaultEnd;
-    $("#startingBalance").value = Number(STATE.settings.startingBalance || 0);
+    renderSettingsForm();
 
     $("#settingsForm").addEventListener("submit", (e) => {
       e.preventDefault();
@@ -465,6 +471,7 @@
         STATE = parsed;
         save(STATE);
         dlg.close();
+        renderSettingsForm();
         recalcAndRender();
       } catch (err) {
         alert("Import failed: " + err.message);


### PR DESCRIPTION
## Summary
- extract a reusable helper that writes the current settings into the settings form fields
- reuse the helper during initialization and after successful imports so the UI always reflects STATE

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd8e55b7a4832bb7fd0d67e41ff3ed