### PR TITLE
Add centered app shell wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,21 +10,22 @@
   <meta name="description" content="Static cash flow forecaster for the rest of 2025. All client-side." />
 </head>
 <body>
-  <header class="app-header">
-    <h1>2025 Cash Flow</h1>
-    <div class="header-actions">
-      <button id="exportBtn" class="btn">Export JSON</button>
-      <button id="importBtn" class="btn btn-outline">Import JSON</button>
-    </div>
-  </header>
+  <div class="app-shell">
+    <header class="app-header">
+      <h1>2025 Cash Flow</h1>
+      <div class="header-actions">
+        <button id="exportBtn" class="btn">Export JSON</button>
+        <button id="importBtn" class="btn btn-outline">Import JSON</button>
+      </div>
+    </header>
 
-  <nav class="tabs">
-    <button class="tab active" data-tab="dashboard">Dashboard</button>
-    <button class="tab" data-tab="movements">Cash Movements</button>
-    <button class="tab" data-tab="income">Income Plan</button>
-  </nav>
+    <nav class="tabs">
+      <button class="tab active" data-tab="dashboard">Dashboard</button>
+      <button class="tab" data-tab="movements">Cash Movements</button>
+      <button class="tab" data-tab="income">Income Plan</button>
+    </nav>
 
-  <main>
+    <main>
     <!-- DASHBOARD -->
     <section id="dashboard" class="tab-panel active">
       <div class="card grid-2">
@@ -242,23 +243,24 @@
         </table>
       </div>
     </section>
-  </main>
+    </main>
 
-  <dialog id="importDialog">
-    <form method="dialog" class="form">
-      <h3>Import JSON</h3>
-      <p>Paste data exported from this app (it will replace your current plan).</p>
-      <textarea id="importText" rows="10" spellcheck="false" placeholder='{"settings":{...},"oneOffs":[...],"incomeStreams":[...]}'></textarea>
-      <div class="actions">
-        <button class="btn btn-outline" value="cancel">Cancel</button>
-        <button id="confirmImportBtn" class="btn" value="default">Import</button>
-      </div>
-    </form>
-  </dialog>
+    <dialog id="importDialog">
+      <form method="dialog" class="form">
+        <h3>Import JSON</h3>
+        <p>Paste data exported from this app (it will replace your current plan).</p>
+        <textarea id="importText" rows="10" spellcheck="false" placeholder='{"settings":{...},"oneOffs":[...],"incomeStreams":[...]}'></textarea>
+        <div class="actions">
+          <button class="btn btn-outline" value="cancel">Cancel</button>
+          <button id="confirmImportBtn" class="btn" value="default">Import</button>
+        </div>
+      </form>
+    </dialog>
 
-  <footer class="app-footer">
-    <small>All data is stored locally in your browser. 💾</small>
-  </footer>
+    <footer class="app-footer">
+      <small>All data is stored locally in your browser. 💾</small>
+    </footer>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -20,9 +20,16 @@ body {
   background-image: linear-gradient(180deg, #F5F7FB 0%, #E8EEFA 100%);
 }
 
+.app-shell {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 0 clamp(16px, 5vw, 48px);
+  min-height: 100%;
+}
+
 .app-header {
   display:flex; align-items:center; justify-content:space-between;
-  padding: 18px 20px; border-bottom: 1px solid var(--border);
+  padding: 18px 0; border-bottom: 1px solid var(--border);
   position: sticky; top: 0; backdrop-filter: blur(6px);
   background: rgba(255,255,255,0.85);
 }
@@ -42,7 +49,7 @@ body {
 .link { background: none; border: none; color: var(--accent); text-decoration: underline; cursor: pointer; }
 
 .tabs {
-  display:flex; gap: 8px; padding: 12px 20px; border-bottom: 1px solid var(--border);
+  display:flex; gap: 8px; padding: 12px 0; border-bottom: 1px solid var(--border);
 }
 .tab {
   background: var(--chip); color: var(--text); border: 1px solid var(--border);
@@ -58,7 +65,7 @@ body {
   box-shadow: 0 0 0 2px rgba(95, 123, 255, 0.2);
 }
 
-main { padding: 20px; display: grid; gap: 16px; }
+main { padding: 20px 0; display: grid; gap: 16px; }
 
 .card {
   background: var(--panel); border: 1px solid var(--border); border-radius: 16px; padding: 16px; box-shadow: 0 20px 40px rgba(17, 25, 40, 0.08);
@@ -97,6 +104,12 @@ main { padding: 20px; display: grid; gap: 16px; }
 .tab-panel { display:none; }
 .tab-panel.active { display:block; }
 
-.app-footer { text-align:center; color: var(--muted); padding: 30px 10px; }
+.app-footer { text-align:center; color: var(--muted); padding: 30px 0; }
+
+@media (max-width: 600px) {
+  .app-shell {
+    padding: 0 clamp(20px, 8vw, 36px);
+  }
+}
 
 canvas { width: 100%; }


### PR DESCRIPTION
## Summary
- wrap the header, tab navigation, main content, and footer in a new `.app-shell` container for shared layout control
- center the app shell with a max-width and responsive horizontal padding while letting child sections inherit spacing

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd907dd228832bb6fc2815eff9b35a