### PR TITLE
Support multi-day weekly schedules

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,10 +168,10 @@
               <label><input id="ooSkipWeekends" type="checkbox" /> Skip weekends</label>
             </div>
             <div class="field tx-recurring-only tx-freq-only tx-freq-weekly tx-freq-biweekly hidden">
-              <label for="ooDOW">Day of Week</label>
-              <select id="ooDOW">
+              <label for="ooDOW">Day(s) of Week</label>
+              <select id="ooDOW" multiple size="7">
                 <option value="0">Sun</option>
-                <option value="1">Mon</option>
+                <option value="1" selected>Mon</option>
                 <option value="2">Tue</option>
                 <option value="3">Wed</option>
                 <option value="4">Thu</option>
@@ -241,10 +241,10 @@
 
           <!-- Weekly/Biweekly -->
           <div class="field freq-only freq-weekly freq-biweekly">
-            <label for="stDOW">Day of Week</label>
-            <select id="stDOW">
+            <label for="stDOW">Day(s) of Week</label>
+            <select id="stDOW" multiple size="7">
               <option value="0">Sun</option>
-              <option value="1">Mon</option>
+              <option value="1" selected>Mon</option>
               <option value="2">Tue</option>
               <option value="3">Wed</option>
               <option value="4">Thu</option>


### PR DESCRIPTION
## Summary
- allow selecting multiple weekdays for weekly and biweekly recurring entries
- update recurrence evaluation and stored data to handle weekday arrays while keeping biweekly anchoring
- display multi-day selections clearly in schedule summaries

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d461a9a930832b8c7671d2cca05c77