### PR TITLE
Add compatibility fallback when importing saved data

### DIFF
--- a/app.js
+++ b/app.js
@@ -1296,7 +1296,13 @@ const shim = {
       e.preventDefault();
       try {
         const parsed = JSON.parse($("#importText").value);
-        const nextState = normalizeState(parsed, { strict: true });
+        let nextState;
+        try {
+          nextState = normalizeState(parsed, { strict: true });
+        } catch (strictErr) {
+          nextState = normalizeState(parsed);
+          console.warn("Import used compatibility mode", strictErr);
+        }
         STATE = nextState;
         save(STATE);
         dlg.close();


### PR DESCRIPTION
## Summary
- allow import to fall back to non-strict normalization when old backups fail strict validation
- log a console warning when compatibility mode is used

## Testing
- not run (static project)


------
https://chatgpt.com/codex/tasks/task_e_68d548cd6034832b95a40e3ae97921a5