### PR TITLE
Handle existing chart before rendering balance graph

### DIFF
--- a/app.js
+++ b/app.js
@@ -1193,8 +1193,20 @@ const shim = {
     const labels = cal.map((r) => r.date);
     const data = cal.map((r) => Number(r.running.toFixed(2)));
 
-    const ctx = $("#balanceChart").getContext("2d");
-    if (balanceChart) balanceChart.destroy();
+    const canvasEl = $("#balanceChart");
+    if (!canvasEl) return;
+
+    const existingChart = typeof Chart?.getChart === "function"
+      ? Chart.getChart(canvasEl)
+      : null;
+    if (existingChart) existingChart.destroy();
+
+    if (balanceChart) {
+      balanceChart.destroy();
+      balanceChart = undefined;
+    }
+
+    const ctx = canvasEl.getContext("2d");
     const lineColors = {
       above: "#1b5e20",
       below: "#b71c1c"


### PR DESCRIPTION
## Summary
- guard balance chart rendering to ensure the canvas element exists
- destroy any registered Chart.js instance tied to the balance chart canvas before creating a new one
- clear the cached chart reference after destroying so subsequent renders start fresh

## Testing
- no automated tests were run (project has no test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d549ddc55c832ba44f251c07583e6c