### PR TITLE
Add PDF export for next 30 days projection

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       <h1>2025 Cash Flow</h1>
       <div class="header-actions">
         <button id="exportBtn" class="btn">Export JSON</button>
+        <button id="pdfBtn" class="btn">Next 30 Days PDF</button>
         <button id="importBtn" class="btn btn-outline">Import JSON</button>
       </div>
     </header>
@@ -372,6 +373,8 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-/Y2ey+t0pQiaZ9TQd1i7uHeH5uhNLa9hdzS5eynp8ctb/KsdeAO4M8SW3Ti9L5sFD3VUykwOc2ir2JoC+8BqlA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.1/jspdf.plugin.autotable.min.js" integrity="sha512-yPGvU8LojRxurx8W0prwPBukgJLL79cW5BKybdQeevhqymKiqiS06kFkVQBRyKQHsrnTG+EzHVa2e5JLmcG0uQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a "Next 30 Days PDF" action in the header that uses jsPDF + autoTable
- extend projection calculations to track income and expense details per day for reporting
- generate a printable PDF covering the next 30 days with per-source income/expense breakdowns and balances

## Testing
- not run (frontend-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d554ca85d4832bb9f1b00e4d5b9921