### PR TITLE
Fix jsPDF detection for PDF export

### DIFF
--- a/app.js
+++ b/app.js
@@ -1378,7 +1378,7 @@ const shim = {
     });
 
     $("#pdfBtn").addEventListener("click", () => {
-      const jsPDF = window.jspdf?.jsPDF;
+      const jsPDF = window.jspdf?.jsPDF || window.jsPDF;
       if (typeof jsPDF !== "function") {
         alert("PDF generator not available.");
         return;


### PR DESCRIPTION
## Summary
- update the PDF export handler to detect jsPDF from both `window.jspdf.jsPDF` and the legacy `window.jsPDF` fallback
- prevent the "PDF generator not available" alert when the library exposes the legacy global

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d556fdd998832bb0c9f1adfd10110d