### PR TITLE
Add expanded quick stats to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,24 @@
             <div class="kpi-label">Total Planned Expenses</div>
             <div class="kpi-value" id="kpiExpenses">$0.00</div>
           </div>
+          <div class="kpi">
+            <div class="kpi-label">Lowest Projected Balance</div>
+            <div class="kpi-value" id="kpiLowestBalance">$0.00</div>
+            <div class="kpi-meta" id="kpiLowestDate">—</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Peak Projected Balance</div>
+            <div class="kpi-value" id="kpiPeakBalance">$0.00</div>
+            <div class="kpi-meta" id="kpiPeakDate">—</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">Days Below $0</div>
+            <div class="kpi-value" id="kpiNegativeDays">0</div>
+          </div>
+          <div class="kpi">
+            <div class="kpi-label">First Negative Day</div>
+            <div class="kpi-value" id="kpiFirstNegative">—</div>
+          </div>
         </div>
       </div>
 

--- a/styles.css
+++ b/styles.css
@@ -100,6 +100,7 @@ main { padding: 20px 0; display: grid; gap: 16px; }
 .kpi { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 12px; box-shadow: 0 12px 24px rgba(17, 25, 40, 0.05); }
 .kpi-label { color: var(--muted); font-size: 12px; margin-bottom: 6px; }
 .kpi-value { font-size: 20px; font-weight: 700; }
+.kpi-meta { color: var(--muted); font-size: 12px; margin-top: 4px; }
 
 .table { width: 100%; border-collapse: collapse; }
 .table th, .table td { padding: 10px; border-bottom: 1px solid var(--border); }


### PR DESCRIPTION
## Summary
- surface additional quick stats for lowest/peak balances, days below zero, and the first negative day in the dashboard
- extend the projection engine with the required metrics and a helper for friendly date formatting
- polish KPI styling with metadata rows for the new contextual details

## Testing
- python3 -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d55dfc3d04832bb65e8bcca7e7aae7