### PR TITLE
Add receivables importer for AR aging files

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
       <button class="tab active" data-tab="dashboard">Dashboard</button>
       <button class="tab" data-tab="movements">Cash Movements</button>
       <button class="tab" data-tab="income">Income Plan</button>
+      <button class="tab" data-tab="receivables">Receivables (AR)</button>
     </nav>
 
     <main>
@@ -375,6 +376,79 @@
         </table>
       </div>
     </section>
+
+    <!-- RECEIVABLES IMPORTER -->
+    <section id="receivables" class="tab-panel">
+      <div class="card">
+        <h2>Receivables (AR) Importer</h2>
+        <div class="ar-controls">
+          <div class="field">
+            <label for="arFile">Upload AR aging file</label>
+            <input id="arFile" type="file" accept=".csv,.xlsx,.xls" />
+          </div>
+        </div>
+
+        <div class="ar-options">
+          <div class="field">
+            <label for="arRoll">Weekend roll</label>
+            <select id="arRoll">
+              <option value="forward" selected>Roll forward</option>
+              <option value="back">Roll back</option>
+              <option value="none">No roll</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="arLag">Payment lag (days)</label>
+            <input id="arLag" type="number" value="0" min="0" step="1" />
+          </div>
+          <div class="field">
+            <label for="arConf">Confidence %</label>
+            <input id="arConf" type="number" value="100" min="0" max="100" step="1" />
+          </div>
+          <div class="field">
+            <label for="arCategory">Category</label>
+            <input id="arCategory" type="text" value="AR" />
+          </div>
+          <div class="field actions-inline">
+            <button id="arParseBtn" type="button" class="btn">Preview</button>
+            <button id="arRecalcBtn" type="button" class="btn btn-outline">Recalculate</button>
+            <button id="arImportBtn" type="button" class="btn" disabled>Import</button>
+          </div>
+        </div>
+
+        <details class="ar-mapping">
+          <summary>Map Columns</summary>
+          <div class="mapping-grid">
+            <label>Company<input id="colCompany" type="text" placeholder="Header for company" /></label>
+            <label>Invoice #<input id="colInvoice" type="text" placeholder="Header for invoice" /></label>
+            <label>Due Date<input id="colDue" type="text" placeholder="Header for due date" /></label>
+            <label>Amount<input id="colAmount" type="text" placeholder="Header for amount" /></label>
+          </div>
+        </details>
+
+        <div id="arStatus" class="ar-status"></div>
+
+        <div class="ar-preview-wrapper">
+          <table id="arPreview" class="table ar-preview">
+            <thead>
+              <tr>
+                <th class="select-col"><input type="checkbox" id="arSelectAll" /></th>
+                <th>Company</th>
+                <th>Invoice</th>
+                <th>Due</th>
+                <th>Expected</th>
+                <th>Amount</th>
+                <th>Name</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <div id="arPagination" class="ar-pagination"></div>
+        <div id="arSummary" class="ar-summary"></div>
+      </div>
+    </section>
     </main>
 
     <dialog id="importDialog">
@@ -398,6 +472,8 @@
   <script src="vendor/jspdf.umd.min.js"></script>
   <script>if (window.jspdf && !window.jsPDF) { window.jsPDF = window.jspdf.jsPDF; }</script>
   <script src="vendor/jspdf.plugin.autotable.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.20.0/dist/xlsx.full.min.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -127,3 +127,41 @@ main { padding: 20px 0; display: grid; gap: 16px; }
 }
 
 canvas { width: 100%; }
+
+.ar-controls { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 12px; }
+.ar-options { display: flex; flex-wrap: wrap; gap: 16px; align-items: flex-end; margin-bottom: 12px; }
+.ar-options .field { min-width: 140px; }
+.ar-options .actions-inline { display: flex; gap: 10px; align-items: center; }
+.ar-mapping { margin-bottom: 12px; }
+.mapping-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); padding-top: 8px; }
+.mapping-grid label { display: flex; flex-direction: column; gap: 6px; font-size: 14px; color: var(--muted); }
+.mapping-grid input { font-size: 14px; padding: 8px 10px; }
+.ar-status { min-height: 20px; font-size: 14px; color: var(--muted); margin-bottom: 8px; }
+.ar-status.error { color: var(--bad); }
+.ar-status.success { color: #047857; }
+.ar-preview-wrapper { max-height: 420px; overflow: auto; border: 1px solid var(--border); border-radius: 12px; }
+.ar-preview { width: 100%; border-collapse: separate; border-spacing: 0; }
+.ar-preview thead th { position: sticky; top: 0; background: #f1f5f9; z-index: 1; }
+.ar-preview tbody tr:nth-child(even) { background: rgba(241, 245, 249, 0.4); }
+.ar-preview tbody tr.invalid { background: rgba(248, 113, 113, 0.08); }
+.ar-preview input { width: 100%; border-radius: 8px; border: 1px solid var(--border); padding: 6px 8px; font-size: 14px; }
+.ar-preview input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(95, 123, 255, 0.18); outline: none; }
+.ar-preview input.invalid { border-color: var(--bad); box-shadow: 0 0 0 2px rgba(241, 101, 100, 0.25); }
+.ar-preview td.invalid-cell { background: rgba(248, 113, 113, 0.12); }
+.ar-preview td { vertical-align: middle; }
+.ar-preview .select-col { width: 54px; text-align: center; }
+.ar-preview .select-col input { width: auto; }
+.ar-pagination { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 10px; flex-wrap: wrap; font-size: 14px; color: var(--muted); }
+.ar-pagination .pager { display: flex; gap: 8px; }
+.ar-pagination button { padding: 6px 10px; border-radius: 8px; border: 1px solid var(--border); background: var(--panel); cursor: pointer; }
+.ar-pagination button[disabled] { opacity: 0.5; cursor: not-allowed; }
+.ar-summary { margin-top: 8px; font-size: 14px; color: var(--muted); }
+.badge { display: inline-flex; align-items: center; gap: 4px; padding: 4px 8px; border-radius: 999px; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; }
+.badge-add { background: #dcfce7; color: #166534; }
+.badge-update { background: #dbeafe; color: #1d4ed8; }
+
+@media (max-width: 720px) {
+  .ar-options { flex-direction: column; align-items: stretch; }
+  .ar-options .actions-inline { justify-content: flex-start; }
+  .ar-preview-wrapper { max-height: 320px; }
+}


### PR DESCRIPTION
## Summary
- add a Receivables (AR) tab with upload controls, column mapping inputs, and preview table for aging files
- implement parsing, normalization, validation, and upsert logic for CSV/XLS/XLSX receivable data
- style the AR importer preview, statuses, and pagination to match the existing UI

## Testing
- node --check app.js

------
https://chatgpt.com/codex/tasks/task_e_68d574e49334832bb0a94654a938e950