### PR TITLE
Add ability to edit one-off transactions from the table

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,7 +231,8 @@
               <input id="ooEscalator" type="number" step="0.01" placeholder="e.g. 2 for 2%" />
             </div>
             <div class="actions">
-              <button class="btn" type="submit">Add</button>
+              <button class="btn" type="submit" id="ooSubmitBtn">Add</button>
+              <button class="btn btn-outline hidden" type="button" id="ooCancelEdit">Cancel</button>
             </div>
           </form>
 


### PR DESCRIPTION
## Summary
- add an Edit action to one-off rows so they can be updated in place
- populate the transaction form when editing, reuse it for saving changes, and restore defaults on cancel
- show contextual Add/Save/Cancel controls while editing a transaction

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6d36d41fc832baa7996384f149882