### PR TITLE
Add cash flow snapshot PDF export

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       <div class="header-actions">
         <button id="exportBtn" class="btn">Export JSON</button>
         <button id="pdfBtn" class="btn">Next 30 Days PDF</button>
+        <button id="snapshotPdfBtn" class="btn">Cash Flow Snapshot PDF</button>
         <button id="importBtn" class="btn btn-outline">Import JSON</button>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add a Cash Flow Snapshot PDF control to the header
- generate a two-page PDF with quick stats, the projected balance chart, and the next 14 days of activity

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6e1287008832bba9438a483e67520