### PR TITLE
Enhance What-If tweaks with linked controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,31 +215,48 @@
             </div>
           </div>
 
-          <div class="whatif-control-block">
-            <h3>Weekly Income Tweaks</h3>
-            <div class="whatif-slider">
-              <label for="whatifGlobalMultiplier">All Streams Multiplier <span id="whatifGlobalMultiplierValue" class="multiplier-value">1.00×</span></label>
-              <input id="whatifGlobalMultiplier" type="range" min="0" max="2" step="0.05" value="1" />
+          <div class="whatif-control-block whatif-global-block">
+            <h3>Global Tweaks</h3>
+            <div class="whatif-global-grid">
+              <label class="whatif-fields">
+                <span>% tweak</span>
+                <div class="whatif-percent-inputs">
+                  <input id="whatifGlobalPct" type="number" min="-100" max="200" step="1" />
+                  <input id="whatifGlobalPctSlider" type="range" min="-100" max="200" step="1" />
+                </div>
+              </label>
+              <label class="whatif-fields">
+                <span>$ tweak</span>
+                <input id="whatifGlobalDelta" type="number" step="0.01" />
+              </label>
+              <label class="whatif-fields">
+                <span>Effective on $100 base</span>
+                <input id="whatifGlobalEffective" type="number" step="0.01" />
+              </label>
             </div>
-            <div id="whatifStreamMultipliers" class="whatif-streams"></div>
+            <div id="whatifGlobalSummary" class="whatif-global-summary"></div>
+          </div>
+
+          <div class="whatif-control-block">
+            <h3>Per-Stream Tweaks</h3>
+            <div id="whatifStreams" class="whatif-streams"></div>
           </div>
 
           <div class="whatif-control-block">
             <h3>Sale Simulator</h3>
             <label class="whatif-toggle"><input id="whatifSaleEnabled" type="checkbox" /> Enable Sale Scenario</label>
             <div id="whatifSaleOptions" class="whatif-sale-options">
-              <div class="whatif-sale-modes">
-                <label><input type="radio" name="whatifSaleMode" value="percent" checked /> % uplift to all income</label>
-                <label><input type="radio" name="whatifSaleMode" value="topup" /> Daily top-up ($)</label>
+              <div class="whatif-sale-grid">
+                <label class="whatif-fields">
+                  <span>% uplift</span>
+                  <input id="whatifSalePercent" type="number" step="1" min="-100" max="500" />
+                </label>
+                <label class="whatif-fields">
+                  <span>$ top-up per day</span>
+                  <input id="whatifSaleTopup" type="number" step="0.01" />
+                </label>
               </div>
-              <div class="whatif-fields" data-sale-mode="percent">
-                <label for="whatifSalePercent">Percent uplift</label>
-                <input id="whatifSalePercent" type="number" step="0.1" min="0" value="15" />
-              </div>
-              <div class="whatif-fields" data-sale-mode="topup">
-                <label for="whatifSaleTopup">Daily top-up ($)</label>
-                <input id="whatifSaleTopup" type="number" step="1" value="0" />
-              </div>
+              <div id="whatifSaleModeLabel" class="whatif-sale-mode-label"></div>
               <div class="whatif-inline">
                 <div class="whatif-fields">
                   <label for="whatifSaleStart">Start</label>

--- a/styles.css
+++ b/styles.css
@@ -136,16 +136,30 @@ main { padding: 20px 0; display: grid; gap: 16px; }
 .whatif-fields label { font-weight: 600; }
 .whatif-slider { display:flex; flex-direction:column; gap:6px; }
 .multiplier-value { font-variant-numeric: tabular-nums; font-size: 13px; color: var(--muted); }
-.whatif-streams { display: flex; flex-direction: column; gap: 10px; }
-.whatif-stream { display: flex; flex-direction: column; gap: 6px; }
-.whatif-stream label { display:flex; justify-content: space-between; align-items: center; font-weight: 600; }
-.whatif-stream .stream-name { flex: 1; margin-right: 12px; }
-.whatif-stream .stream-multiplier { font-variant-numeric: tabular-nums; font-size: 13px; color: var(--muted); }
+.whatif-global-grid { display:grid; gap:10px; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+.whatif-percent-inputs { display:flex; align-items:center; gap:8px; }
+.whatif-percent-inputs input[type="number"] { width: 80px; }
+.whatif-global-summary { font-size: 13px; color: var(--muted); margin-top: 4px; }
+.whatif-streams { display: flex; flex-direction: column; gap: 12px; }
+.whatif-stream { display: flex; flex-direction: column; gap: 12px; border: 1px solid rgba(148, 163, 184, 0.35); border-radius: 12px; padding: 12px; background: rgba(255, 255, 255, 0.85); }
+.whatif-stream-head { display:flex; justify-content:space-between; align-items:flex-start; gap:12px; }
+.whatif-stream-title { display:flex; flex-direction:column; gap:4px; }
+.whatif-stream .stream-name { font-weight:600; }
+.whatif-stream .stream-base { font-size:13px; color: var(--muted); }
+.whatif-lock { border:none; background: rgba(95, 123, 255, 0.08); color: var(--accent); border-radius: 999px; padding: 4px 10px; cursor:pointer; font-size: 18px; line-height:1; display:flex; align-items:center; justify-content:center; }
+.whatif-lock:hover { background: rgba(95, 123, 255, 0.18); }
+.whatif-stream-body { display:grid; gap:12px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); align-items: end; }
+.whatif-field { display:flex; flex-direction:column; gap:6px; font-size:14px; }
+.whatif-field span { font-weight:600; display:flex; align-items:center; justify-content:space-between; }
+.whatif-field small { font-weight:500; color: var(--muted); margin-left: 6px; font-size: 12px; }
+.whatif-field input { width:100%; }
+.whatif-number { font-variant-numeric: tabular-nums; }
+.whatif-stream-actions { display:flex; justify-content:flex-end; align-items:center; grid-column: 1 / -1; }
 .whatif-streams-empty { color: var(--muted); font-size: 13px; font-style: italic; }
 .whatif-toggle { display:flex; align-items:center; gap:8px; font-weight:600; font-size:14px; }
 .whatif-sale-options { display:flex; flex-direction:column; gap:8px; }
-.whatif-sale-modes { display:flex; gap:12px; flex-wrap:wrap; font-size:14px; }
-.whatif-sale-modes label { display:flex; align-items:center; gap:6px; font-weight:600; }
+.whatif-sale-grid { display:grid; gap:12px; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+.whatif-sale-mode-label { font-size: 13px; color: var(--muted); }
 .whatif-inline { display:flex; gap:12px; flex-wrap:wrap; }
 .whatif-inline .whatif-fields { flex:1; min-width: 160px; }
 .whatif-table-header { display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:8px; margin-bottom:8px; }


### PR DESCRIPTION
## Summary
- replace the sandbox multipliers with two-way per-stream tweaks including percent, dollar, effective, and weekly target adjustments that persist in localStorage
- add global tweak inputs and update sale logic so the last edited uplift or top-up drives the scenario computation
- refresh the What-If UI styling to surface the new controls alongside an updated summary label

## Testing
- Viewed in browser (see attached screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68daa63894b0832ba0b4de50c943b6b0