### PR TITLE
Adjust What-If controls layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,11 +238,6 @@
           </div>
 
           <div class="whatif-control-block">
-            <h3>Per-Stream Tweaks</h3>
-            <div id="whatifStreams" class="whatif-streams"></div>
-          </div>
-
-          <div class="whatif-control-block">
             <h3>Sale Simulator</h3>
             <label class="whatif-toggle"><input id="whatifSaleEnabled" type="checkbox" /> Enable Sale Scenario</label>
             <div id="whatifSaleOptions" class="whatif-sale-options">
@@ -269,6 +264,11 @@
               </div>
               <label class="whatif-toggle"><input id="whatifSaleBusinessDays" type="checkbox" /> Only apply on business days</label>
             </div>
+          </div>
+
+          <div class="whatif-control-block whatif-per-stream-block">
+            <h3>Per-Stream Tweaks</h3>
+            <div id="whatifStreams" class="whatif-streams"></div>
           </div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -112,7 +112,31 @@ main { padding: 20px 0; display: grid; gap: 16px; }
 .whatif-controls {
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.whatif-per-stream-block {
+  grid-column: 1 / -1;
+}
+.whatif-streams {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+.whatif-streams > * {
+  height: 100%;
+}
+@media (max-width: 1100px) {
+  .whatif-controls {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 720px) {
+  .whatif-controls {
+    grid-template-columns: 1fr;
+  }
+  .whatif-per-stream-block {
+    grid-column: auto;
+  }
 }
 .whatif-control-block {
   background: rgba(239, 246, 255, 0.6);
@@ -140,7 +164,6 @@ main { padding: 20px 0; display: grid; gap: 16px; }
 .whatif-percent-inputs { display:flex; align-items:center; gap:8px; }
 .whatif-percent-inputs input[type="number"] { width: 80px; }
 .whatif-global-summary { font-size: 13px; color: var(--muted); margin-top: 4px; }
-.whatif-streams { display: flex; flex-direction: column; gap: 12px; }
 .whatif-stream { display: flex; flex-direction: column; gap: 12px; border: 1px solid rgba(148, 163, 184, 0.35); border-radius: 12px; padding: 12px; background: rgba(255, 255, 255, 0.85); }
 .whatif-stream-head { display:flex; justify-content:space-between; align-items:flex-start; gap:12px; }
 .whatif-stream-title { display:flex; flex-direction:column; gap:4px; }


### PR DESCRIPTION
## Summary
- restructure the What-If controls layout to use a three-column grid with the per-stream tweaks spanning the second row
- update the per-stream section to render stream cards in a horizontal grid for better use of space

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68daab74a7b0832b9d9f9037e5a643a3