### PR TITLE
Improve AR importer deduping, preview, and pruning options

### DIFF
--- a/index.html
+++ b/index.html
@@ -575,6 +575,12 @@
             <label for="arCategory">Category</label>
             <input id="arCategory" type="text" value="AR" />
           </div>
+          <div class="field checkbox-field">
+            <label class="checkbox-label">
+              <input id="arPrune" type="checkbox" />
+              Prune invoices missing from this import (archive)
+            </label>
+          </div>
           <div class="field actions-inline">
             <button id="arParseBtn" type="button" class="btn">Preview</button>
             <button id="arRecalcBtn" type="button" class="btn btn-outline">Recalculate</button>
@@ -594,11 +600,18 @@
 
         <div id="arStatus" class="ar-status"></div>
 
+        <div id="arCounters" class="ar-counters"></div>
+
         <div class="ar-preview-wrapper">
           <table id="arPreview" class="table ar-preview">
             <thead>
               <tr>
-                <th class="select-col"><input type="checkbox" id="arSelectAll" /></th>
+                <th class="select-col">
+                  <label class="ar-select-all">
+                    <input type="checkbox" id="arSelectAll" />
+                    <span>Select All (except SAME)</span>
+                  </label>
+                </th>
                 <th>Company</th>
                 <th>Invoice</th>
                 <th>Due</th>

--- a/styles.css
+++ b/styles.css
@@ -264,14 +264,18 @@ canvas { width: 100%; }
 .ar-controls { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 12px; }
 .ar-options { display: flex; flex-wrap: wrap; gap: 16px; align-items: flex-end; margin-bottom: 12px; }
 .ar-options .field { min-width: 140px; }
+.ar-options .checkbox-field { min-width: 260px; }
 .ar-options .actions-inline { display: flex; gap: 10px; align-items: center; }
 .ar-mapping { margin-bottom: 12px; }
 .mapping-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); padding-top: 8px; }
 .mapping-grid label { display: flex; flex-direction: column; gap: 6px; font-size: 14px; color: var(--muted); }
 .mapping-grid input { font-size: 14px; padding: 8px 10px; }
+.checkbox-label { display: flex; align-items: center; gap: 8px; font-size: 14px; color: var(--text); }
+.checkbox-label input { width: auto; }
 .ar-status { min-height: 20px; font-size: 14px; color: var(--muted); margin-bottom: 8px; }
 .ar-status.error { color: var(--bad); }
 .ar-status.success { color: #047857; }
+.ar-counters { margin-bottom: 8px; font-size: 14px; color: var(--muted); display: flex; flex-wrap: wrap; gap: 12px; }
 .ar-preview-wrapper { max-height: 420px; overflow: auto; border: 1px solid var(--border); border-radius: 12px; }
 .ar-preview { width: 100%; border-collapse: separate; border-spacing: 0; }
 .ar-preview thead th { position: sticky; top: 0; background: #f1f5f9; z-index: 1; }
@@ -284,6 +288,8 @@ canvas { width: 100%; }
 .ar-preview td { vertical-align: middle; }
 .ar-preview .select-col { width: 54px; text-align: center; }
 .ar-preview .select-col input { width: auto; }
+.ar-select-all { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; font-size: 11px; text-transform: uppercase; font-weight: 600; letter-spacing: 0.4px; color: var(--muted); }
+.ar-select-all input { margin-bottom: 2px; }
 .ar-pagination { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 10px; flex-wrap: wrap; font-size: 14px; color: var(--muted); }
 .ar-pagination .pager { display: flex; gap: 8px; }
 .ar-pagination button { padding: 6px 10px; border-radius: 8px; border: 1px solid var(--border); background: var(--panel); cursor: pointer; }
@@ -292,6 +298,7 @@ canvas { width: 100%; }
 .badge { display: inline-flex; align-items: center; gap: 4px; padding: 4px 8px; border-radius: 999px; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; }
 .badge-add { background: #dcfce7; color: #166534; }
 .badge-update { background: #dbeafe; color: #1d4ed8; }
+.badge-same { background: #e2e8f0; color: #1f2937; }
 
 @media (max-width: 720px) {
   .ar-options { flex-direction: column; align-items: stretch; }


### PR DESCRIPTION
## Summary
- add pruning toggle, live counters, and improved selection controls to the AR preview UI
- enhance AR parsing with duplicate collapsing, persisted preferences, and action tracking for ADD/UPDATE/SAME
- implement robust import upsert logic with archiving support and exclude archived receivables from projections

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dab392ddb0832b8c3ec5c6fc5ca419