### PR TITLE
Add cash movement dedupe button for AR invoices

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,8 +301,13 @@
     <!-- CASH MOVEMENTS -->
     <section id="movements" class="tab-panel">
       <div class="card">
-        <div>
+        <div class="card-header">
           <h2>One-Off Transactions</h2>
+          <div class="header-actions">
+            <button id="dedupeCashBtn" class="btn btn-outline" type="button">Remove Duplicates</button>
+          </div>
+        </div>
+        <div>
           <form id="oneOffForm" class="form grid-4">
             <div class="field">
               <label for="ooDate">Date</label>


### PR DESCRIPTION
## Summary
- add a "Remove Duplicates" control to the Cash Movements table to clean up extra AR invoices
- implement client-side duplicate detection that preserves the newest pending record while removing older copies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac3348a6c832bb19eea1b11bb1797