### PR TITLE
Refactor: modularize app utilities and components

### DIFF
--- a/components/dashboard.js
+++ b/components/dashboard.js
@@ -1,0 +1,150 @@
+export function createDashboardRenderer({
+  getState,
+  computeProjection,
+  fmtMoney,
+  fmtDate,
+  query,
+  Chart,
+}) {
+  let balanceChart;
+
+  const $ = query;
+
+  const renderDashboard = () => {
+    const state = getState();
+    const {
+      cal,
+      totalIncome,
+      totalExpenses,
+      endBalance,
+      projectedWeeklyIncome,
+      lowestBalance,
+      lowestBalanceDate,
+      peakBalance,
+      peakBalanceDate,
+      firstNegativeDate,
+      negativeDays,
+    } = computeProjection(state);
+
+    $("#kpiEndBalance").textContent = fmtMoney(endBalance);
+    $("#kpiIncome").textContent = fmtMoney(totalIncome);
+    $("#kpiExpenses").textContent = fmtMoney(totalExpenses);
+    const weeklyEl = $("#kpiWeeklyIncome");
+    if (weeklyEl) weeklyEl.textContent = fmtMoney(projectedWeeklyIncome);
+    const lowestEl = $("#kpiLowestBalance");
+    if (lowestEl) lowestEl.textContent = fmtMoney(lowestBalance);
+    const lowestDateEl = $("#kpiLowestDate");
+    if (lowestDateEl) lowestDateEl.textContent = lowestBalanceDate ? `on ${fmtDate(lowestBalanceDate)}` : "—";
+    const peakEl = $("#kpiPeakBalance");
+    if (peakEl) peakEl.textContent = fmtMoney(peakBalance);
+    const peakDateEl = $("#kpiPeakDate");
+    if (peakDateEl) peakDateEl.textContent = peakBalanceDate ? `on ${fmtDate(peakBalanceDate)}` : "—";
+    const negDaysEl = $("#kpiNegativeDays");
+    if (negDaysEl) negDaysEl.textContent = String(negativeDays);
+    const firstNegEl = $("#kpiFirstNegative");
+    if (firstNegEl) firstNegEl.textContent = firstNegativeDate ? fmtDate(firstNegativeDate) : "—";
+
+    const labels = cal.map((r) => r.date);
+    const data = cal.map((r) => Number(r.running.toFixed(2)));
+
+    const canvasEl = $("#balanceChart");
+    if (!canvasEl || typeof Chart !== "function") return;
+
+    const existingChart = typeof Chart?.getChart === "function" ? Chart.getChart(canvasEl) : null;
+    if (existingChart) existingChart.destroy();
+
+    if (balanceChart) {
+      balanceChart.destroy();
+      balanceChart = undefined;
+    }
+
+    const ctx = canvasEl.getContext("2d");
+    const lineColors = {
+      above: "#1b5e20",
+      below: "#b71c1c",
+    };
+    const segmentColor = (segCtx) => {
+      const { chart, p0, p1 } = segCtx || {};
+      const y0 = p0?.parsed?.y;
+      const y1 = p1?.parsed?.y;
+      if (!Number.isFinite(y0) || !Number.isFinite(y1)) return lineColors.above;
+      if (y0 >= 0 && y1 >= 0) return lineColors.above;
+      if (y0 <= 0 && y1 <= 0) return lineColors.below;
+
+      const chartCtx = chart?.ctx;
+      if (!chartCtx) return lineColors.above;
+      const gradient = chartCtx.createLinearGradient(p0.x, p0.y, p1.x, p1.y);
+      const total = Math.abs(y0) + Math.abs(y1);
+      const ratio = total === 0 ? 0.5 : Math.abs(y0) / total;
+      const startColor = y0 >= 0 ? lineColors.above : lineColors.below;
+      const endColor = y1 >= 0 ? lineColors.above : lineColors.below;
+      const midColor = y0 >= 0 ? lineColors.below : lineColors.above;
+      gradient.addColorStop(0, startColor);
+      gradient.addColorStop(Math.min(Math.max(ratio, 0), 1), startColor);
+      gradient.addColorStop(Math.min(Math.max(ratio, 0), 1), midColor);
+      gradient.addColorStop(1, endColor);
+      return gradient;
+    };
+
+    balanceChart = new Chart(ctx, {
+      type: "line",
+      data: {
+        labels,
+        datasets: [
+          {
+            label: "Projected Balance",
+            data,
+            tension: 0.25,
+            borderWidth: 2,
+            pointRadius: 0,
+            borderColor: lineColors.above,
+            segment: { borderColor: segmentColor },
+            fill: {
+              target: { value: 0 },
+              above: "rgba(27, 94, 32, 0.15)",
+              below: "rgba(183, 28, 28, 0.18)",
+            },
+          },
+        ],
+      },
+      options: {
+        interaction: { intersect: false, mode: "index" },
+        plugins: { legend: { display: false } },
+        scales: {
+          x: { ticks: { maxTicksLimit: 10 } },
+          y: {
+            beginAtZero: false,
+            grid: {
+              color: (gridCtx) => {
+                const value = gridCtx.tick && typeof gridCtx.tick.value === "number" ? gridCtx.tick.value : null;
+                return value === 0 ? "#0f172a" : "rgba(148, 163, 184, 0.2)";
+              },
+              lineWidth: (gridCtx) => {
+                const value = gridCtx.tick && typeof gridCtx.tick.value === "number" ? gridCtx.tick.value : null;
+                return value === 0 ? 2 : 1;
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const tbody = $("#upcomingTable tbody");
+    if (!tbody) return;
+    tbody.innerHTML = "";
+    const next14 = cal.slice(0, 14);
+    for (const r of next14) {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `
+        <td>${r.date}</td>
+        <td class="num">${fmtMoney(r.income)}</td>
+        <td class="num">${fmtMoney(r.expenses)}</td>
+        <td class="num">${fmtMoney(r.net)}</td>
+        <td class="num">${fmtMoney(r.running)}</td>
+      `;
+      tbody.appendChild(tr);
+    }
+  };
+
+  return { renderDashboard };
+}

--- a/components/whatif.js
+++ b/components/whatif.js
@@ -1,0 +1,315 @@
+export function createWhatIfRenderer({
+  getState,
+  getSandbox,
+  setSandbox,
+  sanitizeWhatIfState,
+  saveWhatIf,
+  cloneStateForSandbox,
+  defaultState,
+  isValidYMDString,
+  compareYMD,
+  clampPercent,
+  clampCurrency,
+  round2,
+  computeProjection,
+  estimateOccurrencesPerWeek,
+  computeEffectiveAmount,
+  fmtMoney,
+  fmtDate,
+  escapeHtml,
+  describeNameAndCategory,
+  formatPercentLabel,
+  formatMoneyDelta,
+  formatNumberDelta,
+  applyDeltaClass,
+  describeFirstNegative,
+  describeFirstNegativeDelta,
+  createSaleEntry,
+  uid,
+  query,
+}) {
+  const $ = query;
+
+  const renderWhatIf = () => {
+    const panel = $("#whatif");
+    if (!panel) return;
+
+    const state = getState();
+    const prevSandbox = getSandbox();
+    const prevKeys =
+      prevSandbox?.tweaks?.streams && typeof prevSandbox.tweaks.streams === "object"
+        ? Object.keys(prevSandbox.tweaks.streams)
+        : [];
+
+    let sandbox = sanitizeWhatIfState(prevSandbox, state);
+    setSandbox(sandbox);
+
+    const nextKeys =
+      sandbox?.tweaks?.streams && typeof sandbox.tweaks.streams === "object"
+        ? Object.keys(sandbox.tweaks.streams)
+        : [];
+    if (nextKeys.length !== prevKeys.length) {
+      saveWhatIf(sandbox);
+    }
+
+    const tweaks = sandbox.tweaks || {};
+    const baseState = cloneStateForSandbox(sandbox.base);
+    const baseSettings = baseState.settings || defaultState().settings;
+    const startDate = isValidYMDString(tweaks.startDate) ? tweaks.startDate : baseSettings.startDate;
+    let endDate = isValidYMDString(tweaks.endDate) ? tweaks.endDate : baseSettings.endDate;
+    if (compareYMD(startDate, endDate) > 0) endDate = startDate;
+    baseState.settings = { ...baseSettings, startDate, endDate };
+
+    const globalTweaks = tweaks.global || (tweaks.global = { pct: 0, delta: 0, lastEdited: "pct" });
+    globalTweaks.pct = clampPercent(globalTweaks.pct, { min: -1, max: 2, fallback: 0 });
+    globalTweaks.delta = clampCurrency(globalTweaks.delta, 0);
+    if (!["pct", "delta", "effective"].includes(globalTweaks.lastEdited)) {
+      globalTweaks.lastEdited = "pct";
+    }
+
+    const streamTweaks = tweaks.streams || (tweaks.streams = {});
+    const saleTweaks = tweaks.sale || (tweaks.sale = { enabled: false, entries: [] });
+    saleTweaks.enabled = Boolean(saleTweaks.enabled);
+    if (!Array.isArray(saleTweaks.entries)) {
+      saleTweaks.entries = [];
+    }
+    let saleMutated = false;
+    const validSaleEntries = [];
+    for (const entry of saleTweaks.entries) {
+      if (!entry || typeof entry !== "object") {
+        saleMutated = true;
+        continue;
+      }
+      const start = isValidYMDString(entry.startDate) ? entry.startDate : startDate;
+      let finish = isValidYMDString(entry.endDate) ? entry.endDate : start;
+      if (compareYMD(start, finish) > 0) finish = start;
+      const pct = clampPercent(entry.pct, { min: -1, max: 5, fallback: 0 });
+      const topup = clampCurrency(entry.topup, 0);
+      const lastEdited = entry.lastEdited === "topup" ? "topup" : "pct";
+      const id = typeof entry.id === "string" ? entry.id : uid();
+      validSaleEntries.push({
+        id,
+        name: typeof entry.name === "string" ? entry.name.trim().slice(0, 120) : "",
+        pct,
+        topup,
+        startDate: start,
+        endDate: finish,
+        businessDaysOnly: Boolean(entry.businessDaysOnly),
+        lastEdited,
+      });
+    }
+    if (validSaleEntries.length !== saleTweaks.entries.length) {
+      saleMutated = true;
+    }
+    saleTweaks.entries = validSaleEntries;
+    if (saleTweaks.enabled && !saleTweaks.entries.length) {
+      saleTweaks.entries.push(createSaleEntry(startDate));
+      saleMutated = true;
+    }
+
+    const actualProjection = computeProjection(state);
+
+    const streamInfo = [];
+    const streamMap = new Map();
+    let mutated = saleMutated;
+
+    for (const stream of baseState.incomeStreams) {
+      if (!stream || typeof stream !== "object") continue;
+      if (typeof stream.id !== "string") stream.id = uid();
+      const streamId = stream.id;
+      if (!streamTweaks[streamId]) {
+        streamTweaks[streamId] = { pct: 0, delta: 0, effective: null, weeklyTarget: null, lastEdited: "pct" };
+        mutated = true;
+      }
+      const entry = streamTweaks[streamId];
+      entry.pct = clampPercent(entry.pct, { min: -1, max: 2, fallback: 0 });
+      entry.delta = clampCurrency(entry.delta, 0);
+      if (!["pct", "delta", "effective", "weekly"].includes(entry.lastEdited)) {
+        entry.lastEdited = "pct";
+        mutated = true;
+      }
+      if (entry.lastEdited !== "effective" && entry.effective !== null) {
+        entry.effective = null;
+        mutated = true;
+      } else if (entry.lastEdited === "effective" && entry.effective !== null) {
+        entry.effective = round2(entry.effective);
+      }
+      if (entry.lastEdited !== "weekly" && entry.weeklyTarget !== null) {
+        entry.weeklyTarget = null;
+        mutated = true;
+      } else if (entry.lastEdited === "weekly") {
+        if (!Number.isFinite(Number(entry.weeklyTarget))) {
+          entry.weeklyTarget = null;
+          entry.lastEdited = "pct";
+          mutated = true;
+        } else {
+          entry.weeklyTarget = round2(entry.weeklyTarget);
+        }
+      }
+      const baseAmount = Math.abs(Number(stream.amount || 0));
+      const occurrences = estimateOccurrencesPerWeek(stream);
+      if (entry.lastEdited === "weekly" && (!occurrences || occurrences <= 0)) {
+        entry.lastEdited = "pct";
+        entry.weeklyTarget = null;
+        mutated = true;
+      }
+
+      const baseAfterGlobal = computeEffectiveAmount(baseAmount, globalTweaks.pct, globalTweaks.delta);
+      let finalAmount = baseAfterGlobal;
+      if (entry.lastEdited === "weekly" && entry.weeklyTarget !== null && occurrences > 0) {
+        finalAmount = round2(entry.weeklyTarget / occurrences);
+      } else if (entry.lastEdited === "effective" && entry.effective !== null) {
+        finalAmount = round2(entry.effective);
+      } else {
+        finalAmount = computeEffectiveAmount(baseAfterGlobal, entry.pct, entry.delta);
+      }
+
+      streamInfo.push({ id: streamId, stream, baseAmount, baseAfterGlobal, occurrences, entry, finalAmount });
+      streamMap.set(streamId, { entry, occurrences });
+    }
+
+    if (mutated) {
+      saveWhatIf(sandbox);
+    }
+
+    const startInput = $("#whatifStartDate");
+    if (startInput && document.activeElement !== startInput) startInput.value = startDate || "";
+    const endInput = $("#whatifEndDate");
+    if (endInput && document.activeElement !== endInput) endInput.value = endDate || "";
+
+    const pctInput = $("#whatifGlobalPct");
+    if (pctInput && document.activeElement !== pctInput) pctInput.value = String(Math.round(globalTweaks.pct * 100));
+    const pctSlider = $("#whatifGlobalPctSlider");
+    if (pctSlider && document.activeElement !== pctSlider) pctSlider.value = String(Math.round(globalTweaks.pct * 100));
+    const deltaInput = $("#whatifGlobalDelta");
+    if (deltaInput && document.activeElement !== deltaInput) deltaInput.value = String(round2(globalTweaks.delta));
+    const globalEffective = computeEffectiveAmount(100, globalTweaks.pct, globalTweaks.delta);
+    const effectiveInput = $("#whatifGlobalEffective");
+    if (effectiveInput && document.activeElement !== effectiveInput) effectiveInput.value = globalEffective.toFixed(2);
+    const globalSummary = $("#whatifGlobalSummary");
+    if (globalSummary) {
+      const pctLabel = formatPercentLabel(globalTweaks.pct);
+      globalSummary.textContent = `Applied before per-stream tweaks · ${pctLabel} & ${formatMoneyDelta(globalTweaks.delta)} per occurrence · $100 → ${fmtMoney(globalEffective)}`;
+    }
+
+    const streamContainer = $("#whatifStreams");
+    if (streamContainer) {
+      if (!streamInfo.length) {
+        streamContainer.innerHTML = '<p class="whatif-streams-empty">No recurring income streams in sandbox.</p>';
+      } else {
+        streamContainer.innerHTML = streamInfo
+          .map(({ id, stream, baseAmount, baseAfterGlobal, occurrences, entry, finalAmount }) => {
+            const name = escapeHtml(describeNameAndCategory(stream, "Income Stream"));
+            const pctValue = String(Math.round(entry.pct * 100));
+            const deltaValue = entry.delta.toFixed(2);
+            const effectiveValue = finalAmount.toFixed(2);
+            const weeklyValue = entry.lastEdited === "weekly" && entry.weeklyTarget !== null ? entry.weeklyTarget.toFixed(2) : "";
+            const weeklyDisabled = !occurrences || occurrences <= 0;
+            const weeklyLabel = occurrences && occurrences > 0 ? `${round2(occurrences)} / week` : "n/a";
+            const isLocked = entry.lastEdited === "effective" || entry.lastEdited === "weekly";
+            const lockIcon = isLocked ? "🔒" : "🔗";
+            const lockTitle = isLocked ? "Unlock to use %/$ tweaks" : "Lock current effective amount";
+            const baseLabel = baseAmount === baseAfterGlobal
+              ? `Base: ${fmtMoney(baseAmount)}`
+              : `Base: ${fmtMoney(baseAmount)} · Post-global: ${fmtMoney(baseAfterGlobal)}`;
+            return `
+<div class="whatif-stream" data-stream="${id}">
+  <div class="whatif-stream-head">
+    <div>
+      <h4>${name}</h4>
+      <p>${baseLabel}</p>
+    </div>
+    <div class="whatif-stream-lock" data-stream="${id}" data-locked="${isLocked ? "1" : "0"}" title="${lockTitle}">${lockIcon}</div>
+  </div>
+  <div class="whatif-stream-body">
+    <label>% <input type="number" class="whatif-stream-pct" data-stream="${id}" value="${pctValue}" ${entry.lastEdited === "pct" ? "" : "disabled"}></label>
+    <label>Δ $ <input type="number" step="0.01" class="whatif-stream-delta" data-stream="${id}" value="${deltaValue}" ${entry.lastEdited === "delta" ? "" : "disabled"}></label>
+    <label>Effective <input type="number" step="0.01" class="whatif-stream-effective" data-stream="${id}" value="${effectiveValue}" ${entry.lastEdited === "effective" ? "" : "disabled"}></label>
+    <label class="weekly">
+      Weekly target
+      <input type="number" step="0.01" class="whatif-stream-weekly" data-stream="${id}" value="${weeklyValue}" ${entry.lastEdited === "weekly" ? "" : "disabled"} ${weeklyDisabled ? "disabled" : ""}>
+      <small>${weeklyLabel}</small>
+    </label>
+  </div>
+</div>`;
+          })
+          .join("");
+      }
+    }
+
+    const projection = computeProjection(baseState, {
+      transformStreamAmount: ({ stream, baseAmount, date }) => {
+        const info = streamMap.get(stream.id);
+        if (!info) return baseAmount;
+        const { entry, occurrences } = info;
+        if (entry.lastEdited === "weekly" && entry.weeklyTarget !== null && occurrences > 0) {
+          return entry.weeklyTarget / occurrences;
+        }
+        if (entry.lastEdited === "effective" && entry.effective !== null) {
+          return entry.effective;
+        }
+        return computeEffectiveAmount(baseAmount, entry.pct, entry.delta);
+      },
+      sale: saleTweaks.enabled
+        ? { enabled: true, entries: saleTweaks.entries }
+        : null,
+    });
+
+    $("#whatifProjectedBalance").textContent = fmtMoney(projection.endBalance);
+    $("#whatifProjectedIncome").textContent = fmtMoney(projection.totalIncome);
+    $("#whatifProjectedExpenses").textContent = fmtMoney(projection.totalExpenses);
+
+    const deltas = {
+      balance: projection.endBalance - actualProjection.endBalance,
+      income: projection.totalIncome - actualProjection.totalIncome,
+      expenses: projection.totalExpenses - actualProjection.totalExpenses,
+      lowest: projection.lowestBalance - actualProjection.lowestBalance,
+      peak: projection.peakBalance - actualProjection.peakBalance,
+      negatives: projection.negativeDays - actualProjection.negativeDays,
+    };
+
+    $("#whatifProjectedBalanceDelta").textContent = formatMoneyDelta(deltas.balance);
+    $("#whatifProjectedIncomeDelta").textContent = formatMoneyDelta(deltas.income);
+    $("#whatifProjectedExpensesDelta").textContent = formatMoneyDelta(deltas.expenses);
+    $("#whatifProjectedLowest").textContent = fmtMoney(projection.lowestBalance);
+    $("#whatifProjectedPeak").textContent = fmtMoney(projection.peakBalance);
+    $("#whatifProjectedNegativeDays").textContent = String(projection.negativeDays);
+    $("#whatifProjectedFirstNegative").textContent = describeFirstNegative(projection.firstNegativeDate);
+
+    applyDeltaClass($("#whatifProjectedBalanceDelta"), deltas.balance);
+    applyDeltaClass($("#whatifProjectedIncomeDelta"), deltas.income);
+    applyDeltaClass($("#whatifProjectedExpensesDelta"), deltas.expenses, { positiveIsGood: false });
+    applyDeltaClass($("#whatifProjectedNegativeDaysDelta"), deltas.negatives, { positiveIsGood: false });
+
+    const lowestDelta = describeFirstNegativeDelta(actualProjection.lowestBalanceDate, projection.lowestBalanceDate);
+    $("#whatifProjectedLowestDelta").textContent = lowestDelta.text;
+    applyDeltaClass($("#whatifProjectedLowestDelta"), lowestDelta.delta, { positiveIsGood: false });
+
+    const peakDelta = describeFirstNegativeDelta(actualProjection.peakBalanceDate, projection.peakBalanceDate);
+    $("#whatifProjectedPeakDelta").textContent = peakDelta.text;
+    applyDeltaClass($("#whatifProjectedPeakDelta"), peakDelta.delta);
+
+    const firstNegDelta = describeFirstNegativeDelta(actualProjection.firstNegativeDate, projection.firstNegativeDate);
+    $("#whatifProjectedFirstNegativeDelta").textContent = firstNegDelta.text;
+    applyDeltaClass($("#whatifProjectedFirstNegativeDelta"), firstNegDelta.delta, { positiveIsGood: false });
+
+    const saleContainer = $("#whatifSaleEntries");
+    if (saleContainer) {
+      saleContainer.innerHTML = saleTweaks.entries
+        .map((entry) => {
+          const name = escapeHtml(entry.name || "Sale");
+          const pct = formatPercentLabel(entry.pct);
+          const topup = formatMoneyDelta(entry.topup);
+          return `
+<li data-sale-id="${entry.id}">
+  <strong>${name}</strong>
+  <span>${entry.startDate} → ${entry.endDate}</span>
+  <span>${pct}, top-up ${topup}</span>
+</li>`;
+        })
+        .join("");
+    }
+  };
+
+  return { renderWhatIf };
+}

--- a/index.html
+++ b/index.html
@@ -652,6 +652,6 @@
   <script src="vendor/jspdf.plugin.autotable.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.20.0/dist/xlsx.full.min.js"></script>
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/state/management.js
+++ b/state/management.js
@@ -1,0 +1,512 @@
+import {
+  todayYMD,
+  compareYMD,
+  fromYMD,
+  toYMD,
+  toWeekdayArray,
+  normalizeNth,
+  firstWeekday,
+} from "../utils/dates.js";
+import { clamp, round2, uid, deepClone } from "../utils/formatting.js";
+
+export const STORAGE_KEYS = {
+  STATE: "cashflow2025_v1",
+  WHAT_IF: "cashflow2025_whatif_v1",
+  AR_PREFS: "cashflow2025_arPrefs_v1",
+};
+
+export const DEFAULT_CONFIG = {
+  END_DATE: "2025-12-31",
+};
+
+const ONE_OFF_SORT_KEYS = ["date", "schedule", "type", "name", "category", "next"];
+
+export const defaultOneOffSortState = () => ({ key: "date", direction: "asc" });
+
+export const sanitizeOneOffSortState = (value) => {
+  const defaults = defaultOneOffSortState();
+  if (!value || typeof value !== "object") return defaults;
+  const key = ONE_OFF_SORT_KEYS.includes(value.key) ? value.key : defaults.key;
+  const direction = value.direction === "desc" ? "desc" : defaults.direction;
+  return { key, direction };
+};
+
+export const defaultState = () => ({
+  settings: {
+    startDate: todayYMD,
+    endDate: DEFAULT_CONFIG.END_DATE,
+    startingBalance: 0,
+  },
+  adjustments: [],
+  oneOffs: [],
+  incomeStreams: [],
+  ui: {
+    oneOffSort: defaultOneOffSortState(),
+  },
+});
+
+export const isValidYMDString = (value) => {
+  if (typeof value !== "string" || !value) return false;
+  const parsed = fromYMD(value);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return toYMD(parsed) === value;
+};
+
+export const createSaleEntry = (startDate) => {
+  const safeStart = isValidYMDString(startDate) ? startDate : todayYMD;
+  return {
+    id: uid(),
+    name: "",
+    pct: 0,
+    topup: 0,
+    startDate: safeStart,
+    endDate: safeStart,
+    businessDaysOnly: true,
+    lastEdited: "pct",
+  };
+};
+
+const sanitizeSteps = (steps) => {
+  if (!Array.isArray(steps)) return [];
+  return steps
+    .map((step) => {
+      if (!step || typeof step !== "object") return null;
+      const date = typeof step.effectiveFrom === "string" ? step.effectiveFrom : null;
+      const amount = Number(step.amount || 0);
+      if (!date || !Number.isFinite(amount) || amount <= 0) return null;
+      return { effectiveFrom: date, amount: Math.abs(amount) };
+    })
+    .filter((step) => step !== null)
+    .sort((a, b) => compareYMD(a.effectiveFrom, b.effectiveFrom));
+};
+
+const sanitizeOneOff = (entry, { strict = false } = {}) => {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    if (strict) throw new Error("Invalid one-off entry");
+    return null;
+  }
+
+  const result = { ...entry };
+  result.id = typeof entry.id === "string" ? entry.id : uid();
+  result.type = entry.type === "expense" ? "expense" : "income";
+  result.recurring = Boolean(entry.recurring || entry.repeats);
+  result.steps = sanitizeSteps(entry.steps);
+  result.escalatorPct = Number.isFinite(Number(entry.escalatorPct || 0)) ? Number(entry.escalatorPct || 0) : 0;
+
+  if (result.recurring) {
+    const frequency = typeof entry.frequency === "string" ? entry.frequency : "monthly";
+    result.frequency = frequency;
+    result.startDate = typeof entry.startDate === "string" ? entry.startDate : typeof entry.date === "string" ? entry.date : null;
+    result.endDate = typeof entry.endDate === "string" ? entry.endDate : typeof entry.date === "string" ? entry.date : null;
+
+    if (!result.startDate || !result.endDate || !isValidYMDString(result.startDate) || !isValidYMDString(result.endDate)) {
+      if (strict) throw new Error("Invalid recurring one-off date range");
+      return null;
+    }
+    if (compareYMD(result.startDate, result.endDate) > 0) {
+      if (strict) throw new Error("Invalid recurring one-off range");
+      result.endDate = result.startDate;
+    }
+    result.skipWeekends = Boolean(entry.skipWeekends);
+
+    if (entry.dayOfWeek !== undefined) {
+      result.dayOfWeek = toWeekdayArray(entry.dayOfWeek);
+    }
+    if (entry.dayOfMonth !== undefined) {
+      result.dayOfMonth = clamp(Number(entry.dayOfMonth || 1), 1, 31);
+    }
+
+    if (frequency === "monthly") {
+      const monthlyMode = entry.monthlyMode === "nth" ? "nth" : "day";
+      if (monthlyMode === "nth") {
+        result.monthlyMode = "nth";
+        result.nthWeek = normalizeNth(entry.nthWeek);
+        const nthWeekdaySource =
+          entry.nthWeekday !== undefined
+            ? entry.nthWeekday
+            : entry.dayOfWeek !== undefined
+            ? entry.dayOfWeek
+            : result.dayOfWeek ?? 0;
+        result.nthWeekday = firstWeekday(nthWeekdaySource, 0);
+      } else {
+        result.monthlyMode = "day";
+        const domSource = entry.dayOfMonth !== undefined ? entry.dayOfMonth : result.dayOfMonth ?? 1;
+        result.dayOfMonth = clamp(Number(domSource || 1), 1, 31);
+      }
+    } else {
+      result.monthlyMode = "day";
+    }
+    if (frequency === "weekly" || frequency === "biweekly") {
+      result.dayOfWeek = toWeekdayArray(result.dayOfWeek);
+    }
+    if (result.monthlyMode !== "nth") {
+      delete result.nthWeek;
+      delete result.nthWeekday;
+    }
+    if (typeof entry.onDate === "string") result.onDate = entry.onDate;
+    if (typeof entry.date === "string") result.date = entry.date;
+    else result.date = result.startDate;
+  } else {
+    const date = typeof entry.date === "string" ? entry.date : null;
+    if (!date) {
+      if (strict) throw new Error("Invalid one-off date");
+      return null;
+    }
+    result.date = date;
+    result.steps = [];
+    result.escalatorPct = 0;
+  }
+
+  return result;
+};
+
+const sanitizeList = (list) =>
+  list
+    .map((item) => sanitizeOneOff(item))
+    .filter((item) => item !== null);
+
+const sanitizeStream = (entry, { strict = false } = {}) => {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    if (strict) throw new Error("Invalid income stream record");
+    return null;
+  }
+
+  const amount = Number(entry.amount || 0);
+  if (!Number.isFinite(amount)) {
+    if (strict) throw new Error("Invalid income stream amount");
+    return null;
+  }
+
+  const frequency = typeof entry.frequency === "string" ? entry.frequency : "once";
+  const startDate = typeof entry.startDate === "string" ? entry.startDate : typeof entry.onDate === "string" ? entry.onDate : null;
+  const endDate = typeof entry.endDate === "string" ? entry.endDate : typeof entry.onDate === "string" ? entry.onDate : null;
+  const datesValid = startDate && endDate && isValidYMDString(startDate) && isValidYMDString(endDate);
+  if (!datesValid) {
+    if (strict) throw new Error("Invalid income stream date range");
+    return null;
+  }
+
+  const startVsEnd = compareYMD(startDate, endDate);
+  const normalizedStart = startVsEnd <= 0 ? startDate : endDate;
+  const normalizedEnd = startVsEnd <= 0 ? endDate : startDate;
+
+  const id = typeof entry.id === "string" ? entry.id : uid();
+  const stream = {
+    id,
+    name: typeof entry.name === "string" ? entry.name : "",
+    category: typeof entry.category === "string" ? entry.category : "",
+    amount: Math.abs(amount),
+    frequency,
+    startDate: normalizedStart,
+    endDate: normalizedEnd,
+    onDate: typeof entry.onDate === "string" ? entry.onDate : null,
+    skipWeekends: Boolean(entry.skipWeekends),
+    dayOfWeek: clamp(Number(entry.dayOfWeek ?? 0), 0, 6),
+    dayOfMonth: clamp(Number(entry.dayOfMonth ?? 1), 1, 31),
+    steps: sanitizeSteps(entry.steps),
+    escalatorPct: Number.isFinite(Number(entry.escalatorPct || 0)) ? Number(entry.escalatorPct || 0) : 0,
+  };
+
+  if (frequency === "once") {
+    stream.onDate = typeof entry.onDate === "string" ? entry.onDate : stream.startDate;
+  }
+  if (frequency === "daily") {
+    stream.skipWeekends = Boolean(entry.skipWeekends);
+  }
+  if (frequency === "weekly" || frequency === "biweekly") {
+    stream.dayOfWeek = clamp(Number(entry.dayOfWeek ?? 0), 0, 6);
+  }
+  if (frequency === "monthly") {
+    stream.dayOfMonth = clamp(Number(entry.dayOfMonth ?? 1), 1, 31);
+  }
+
+  return stream;
+};
+
+export const normalizeState = (raw, { strict = false } = {}) => {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("Invalid state payload");
+  }
+
+  const base = defaultState();
+  const state = { ...base, ...raw };
+
+  const rawSettings = raw.settings;
+  if (rawSettings && typeof rawSettings === "object" && !Array.isArray(rawSettings)) {
+    state.settings = { ...base.settings, ...rawSettings };
+  } else {
+    if (strict) throw new Error("Invalid settings data");
+    state.settings = { ...base.settings };
+  }
+
+  if (raw.ui && typeof raw.ui === "object" && !Array.isArray(raw.ui)) {
+    state.ui = { ...base.ui, ...raw.ui };
+    state.ui.oneOffSort = sanitizeOneOffSortState(raw.ui.oneOffSort);
+  } else {
+    if (strict && raw.ui !== undefined) throw new Error("Invalid ui data");
+    state.ui = { ...base.ui };
+  }
+
+  const ensureArray = (key) => {
+    const list = raw[key];
+    if (Array.isArray(list)) {
+      state[key] = list.filter((item) => item && typeof item === "object");
+    } else {
+      if (strict && list !== undefined) throw new Error(`Invalid ${key} data`);
+      state[key] = [];
+    }
+  };
+
+  ensureArray("adjustments");
+  ensureArray("oneOffs");
+  ensureArray("incomeStreams");
+
+  const sanitizeAdjustments = (list) =>
+    list
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") return null;
+        const date = typeof entry.date === "string" ? entry.date : null;
+        if (!date || !isValidYMDString(date)) return null;
+        const amount = Number(entry.amount || 0);
+        if (!Number.isFinite(amount)) return null;
+        return {
+          id: typeof entry.id === "string" ? entry.id : uid(),
+          date,
+          amount,
+          note: typeof entry.note === "string" ? entry.note : "",
+        };
+      })
+      .filter((entry) => entry !== null);
+
+  state.adjustments = sanitizeAdjustments(state.adjustments);
+  state.oneOffs = sanitizeList(state.oneOffs);
+  state.incomeStreams = state.incomeStreams
+    .map((entry) => sanitizeStream(entry))
+    .filter((entry) => entry !== null);
+
+  const legacyExpenses = Array.isArray(raw.expenseStreams) ? raw.expenseStreams : [];
+  if (legacyExpenses.length) {
+    const fallbackStart = state.settings.startDate;
+    const fallbackEnd = state.settings.endDate;
+    const mapped = legacyExpenses
+      .map((stream) => {
+        if (!stream || typeof stream !== "object" || Array.isArray(stream)) {
+          if (strict) throw new Error("Invalid legacy expense stream");
+          return null;
+        }
+        const candidate = {
+          ...stream,
+          id: typeof stream.id === "string" ? stream.id : uid(),
+          type: "expense",
+          recurring: true,
+          date: typeof stream.startDate === "string" ? stream.startDate : stream.onDate,
+          startDate: typeof stream.startDate === "string" ? stream.startDate : fallbackStart,
+          endDate: typeof stream.endDate === "string" ? stream.endDate : fallbackEnd,
+        };
+        return sanitizeOneOff(candidate);
+      })
+      .filter((item) => item !== null);
+    if (mapped.length) {
+      state.oneOffs = [...state.oneOffs, ...mapped];
+    }
+  }
+
+  delete state.expenseStreams;
+
+  if (typeof state.settings.startDate !== "string") {
+    if (strict) throw new Error("Invalid settings.startDate");
+    state.settings.startDate = base.settings.startDate;
+  }
+  if (typeof state.settings.endDate !== "string") {
+    if (strict) throw new Error("Invalid settings.endDate");
+    state.settings.endDate = base.settings.endDate;
+  }
+  if (!isValidYMDString(state.settings.startDate)) {
+    if (strict) throw new Error("Invalid settings.startDate format");
+    state.settings.startDate = base.settings.startDate;
+  }
+  if (!isValidYMDString(state.settings.endDate)) {
+    if (strict) throw new Error("Invalid settings.endDate format");
+    state.settings.endDate = base.settings.endDate;
+  }
+  if (compareYMD(state.settings.startDate, state.settings.endDate) > 0) {
+    if (strict) throw new Error("Invalid settings date range");
+    state.settings.endDate = state.settings.startDate;
+  }
+  const sb = Number(state.settings.startingBalance);
+  if (Number.isFinite(sb)) {
+    state.settings.startingBalance = sb;
+  } else {
+    if (strict) throw new Error("Invalid settings.startingBalance");
+    state.settings.startingBalance = base.settings.startingBalance;
+  }
+
+  return state;
+};
+
+export const loadState = () => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.STATE);
+    if (!raw) return defaultState();
+    const data = JSON.parse(raw);
+    return normalizeState(data);
+  } catch {
+    return defaultState();
+  }
+};
+
+export const saveState = (state) => {
+  localStorage.setItem(STORAGE_KEYS.STATE, JSON.stringify(state));
+};
+
+export const clampPercent = (value, { min = -1, max = 2, fallback = 0 } = {}) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return Math.max(min, Math.min(max, Math.round(num * 1000) / 1000));
+};
+
+export const clampCurrency = (value, fallback = 0) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return round2(num);
+};
+
+export const computeEffectiveAmount = (base, pct, delta) => {
+  const b = Number(base || 0);
+  const p = Number(pct || 0);
+  const d = Number(delta || 0);
+  if (!Number.isFinite(b) || !Number.isFinite(p) || !Number.isFinite(d)) return 0;
+  return round2(b * (1 + p) + d);
+};
+
+export const resolvePercentFromEffective = (base, effective, delta = 0) => {
+  const b = Number(base || 0);
+  if (!Number.isFinite(b) || b === 0) return 0;
+  const e = Number(effective || 0);
+  if (!Number.isFinite(e)) return 0;
+  const d = Number(delta || 0);
+  if (!Number.isFinite(d)) return 0;
+  return clampPercent((e - d) / b - 1);
+};
+
+export const cloneStateForSandbox = (src) => {
+  try {
+    return normalizeState(deepClone(src) ?? {});
+  } catch {
+    return normalizeState(defaultState());
+  }
+};
+
+export const getStreamById = (state, id) => {
+  if (!state || !Array.isArray(state.incomeStreams)) return null;
+  return state.incomeStreams.find((stream) => stream && typeof stream.id === "string" && stream.id === id) || null;
+};
+
+export const getStreamBaseAmount = (stream) => {
+  if (!stream || typeof stream !== "object") return 0;
+  return Math.abs(Number(stream.amount || 0)) || 0;
+};
+
+export const sanitizeWhatIfState = (raw, fallbackBase = defaultState()) => {
+  const fallback = cloneStateForSandbox(fallbackBase);
+  const baseRaw = raw && typeof raw === "object" ? raw.base : null;
+  const base = baseRaw ? cloneStateForSandbox(baseRaw) : fallback;
+
+  if (!Array.isArray(base.incomeStreams)) base.incomeStreams = [];
+
+  const baseSettings = base.settings || fallback.settings || defaultState().settings;
+  const tweaksRaw = raw && typeof raw === "object" && typeof raw.tweaks === "object" ? raw.tweaks : {};
+
+  const globalRaw = tweaksRaw.global && typeof tweaksRaw.global === "object" ? tweaksRaw.global : {};
+  const global = {
+    pct: clampPercent(globalRaw.pct, { min: -1, max: 2, fallback: 0 }),
+    delta: clampCurrency(globalRaw.delta, 0),
+    lastEdited: ["pct", "delta", "effective"].includes(globalRaw.lastEdited) ? globalRaw.lastEdited : "pct",
+  };
+
+  const streamsRaw = tweaksRaw.streams && typeof tweaksRaw.streams === "object" ? tweaksRaw.streams : {};
+  const streams = {};
+  for (const stream of base.incomeStreams) {
+    if (!stream || typeof stream !== "object") continue;
+    if (typeof stream.id !== "string") stream.id = uid();
+    const streamId = stream.id;
+    const rawEntry = streamsRaw && typeof streamsRaw[streamId] === "object" ? streamsRaw[streamId] : {};
+    const pct = clampPercent(rawEntry.pct, { min: -1, max: 2, fallback: 0 });
+    const delta = clampCurrency(rawEntry.delta, 0);
+    const effective = Number.isFinite(Number(rawEntry.effective)) ? round2(Number(rawEntry.effective)) : null;
+    const weeklyTarget = Number.isFinite(Number(rawEntry.weeklyTarget)) ? round2(Number(rawEntry.weeklyTarget)) : null;
+    const lastEdited = ["pct", "delta", "effective", "weekly"].includes(rawEntry.lastEdited)
+      ? rawEntry.lastEdited
+      : "pct";
+    streams[streamId] = { pct, delta, effective, weeklyTarget, lastEdited };
+  }
+
+  const startDate = isValidYMDString(tweaksRaw.startDate) ? tweaksRaw.startDate : baseSettings.startDate;
+  let endDate = isValidYMDString(tweaksRaw.endDate) ? tweaksRaw.endDate : baseSettings.endDate;
+  if (compareYMD(startDate, endDate) > 0) endDate = startDate;
+
+  const saleRaw = tweaksRaw.sale && typeof tweaksRaw.sale === "object" ? tweaksRaw.sale : {};
+  const legacyStart = isValidYMDString(saleRaw.startDate) ? saleRaw.startDate : startDate;
+  let legacyEnd = isValidYMDString(saleRaw.endDate) ? saleRaw.endDate : legacyStart;
+  if (compareYMD(legacyStart, legacyEnd) > 0) legacyEnd = legacyStart;
+  const saleEntriesRaw = Array.isArray(saleRaw.entries) ? saleRaw.entries : null;
+  const legacyEntryNeeded =
+    !saleEntriesRaw &&
+    (saleRaw.startDate || saleRaw.endDate || saleRaw.pct || saleRaw.topup || saleRaw.businessDaysOnly);
+  const combinedEntries = saleEntriesRaw || (legacyEntryNeeded ? [{ ...saleRaw, startDate: legacyStart, endDate: legacyEnd }] : []);
+  const saleEntries = [];
+  for (const rawEntry of combinedEntries) {
+    if (!rawEntry || typeof rawEntry !== "object") continue;
+    const entry = { ...rawEntry };
+    const entryStart = isValidYMDString(entry.startDate) ? entry.startDate : legacyStart;
+    let entryEnd = isValidYMDString(entry.endDate) ? entry.endDate : entryStart;
+    if (compareYMD(entryStart, entryEnd) > 0) entryEnd = entryStart;
+    const entryPct = clampPercent(entry.pct, { min: -1, max: 5, fallback: 0 });
+    const entryTopup = clampCurrency(entry.topup, 0);
+    const lastEdited = entry.lastEdited === "topup" ? "topup" : "pct";
+    const id = typeof entry.id === "string" ? entry.id : uid();
+    const name = typeof entry.name === "string" ? entry.name.trim().slice(0, 120) : "";
+    saleEntries.push({
+      id,
+      name,
+      pct: entryPct,
+      topup: entryTopup,
+      startDate: entryStart,
+      endDate: entryEnd,
+      businessDaysOnly: Boolean(entry.businessDaysOnly),
+      lastEdited,
+    });
+  }
+
+  const sale = {
+    enabled: Boolean(saleRaw.enabled),
+    entries: saleEntries,
+  };
+
+  return {
+    base,
+    tweaks: {
+      global,
+      streams,
+      sale,
+      startDate,
+      endDate,
+    },
+  };
+};
+
+export const loadWhatIf = (fallbackBase) => {
+  const fallback = fallbackBase || defaultState();
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.WHAT_IF);
+    if (!raw) return sanitizeWhatIfState({ base: fallback }, fallback);
+    const data = JSON.parse(raw);
+    return sanitizeWhatIfState(data, fallback);
+  } catch {
+    return sanitizeWhatIfState({ base: fallback }, fallback);
+  }
+};
+
+export const saveWhatIf = (sandbox) => {
+  localStorage.setItem(STORAGE_KEYS.WHAT_IF, JSON.stringify(sandbox));
+};

--- a/utils/dates.js
+++ b/utils/dates.js
@@ -1,0 +1,190 @@
+export const pad = (n) => String(n).padStart(2, "0");
+
+export const toYMD = (d) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+export const fromYMD = (s) => {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+};
+
+export const addDays = (ymd, days = 0) => {
+  if (!ymd || typeof ymd !== "string") return ymd;
+  const delta = Number(days || 0);
+  if (!Number.isFinite(delta)) return ymd;
+  const d = fromYMD(ymd);
+  if (Number.isNaN(d.getTime())) return ymd;
+  d.setDate(d.getDate() + delta);
+  return toYMD(d);
+};
+
+export const rollWeekend = (ymd, policy = "forward") => {
+  if (!ymd || typeof ymd !== "string") return ymd;
+  const d = fromYMD(ymd);
+  if (Number.isNaN(d.getTime())) return ymd;
+  const moveForward = () => {
+    do {
+      d.setDate(d.getDate() + 1);
+    } while (d.getDay() === 0 || d.getDay() === 6);
+  };
+  const moveBack = () => {
+    do {
+      d.setDate(d.getDate() - 1);
+    } while (d.getDay() === 0 || d.getDay() === 6);
+  };
+  if (d.getDay() === 6 || d.getDay() === 0) {
+    if (policy === "back") moveBack();
+    else if (policy === "forward") moveForward();
+  }
+  return toYMD(d);
+};
+
+export const parseExcelOrISODate = (value) => {
+  if (value === null || value === undefined || value === "") return null;
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null;
+    return toYMD(value);
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const serial = Number(value);
+    const whole = Math.floor(serial);
+    const frac = serial - whole;
+    let days = whole;
+    if (days > 59) days -= 1;
+    const epoch = Date.UTC(1899, 11, 31);
+    const ms = epoch + days * 86400000 + Math.round(frac * 86400000);
+    const dt = new Date(ms);
+    if (Number.isNaN(dt.getTime())) return null;
+    return `${dt.getUTCFullYear()}-${pad(dt.getUTCMonth() + 1)}-${pad(dt.getUTCDate())}`;
+  }
+  const str = String(value).trim();
+  if (!str) return null;
+  if (/^\d{4}-\d{1,2}-\d{1,2}$/.test(str)) {
+    const [y, m, d] = str.split("-").map(Number);
+    const dt = new Date(y, m - 1, d);
+    if (Number.isNaN(dt.getTime())) return null;
+    return toYMD(dt);
+  }
+  const [datePart] = str.split(/\s+/);
+  if (/^\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4}$/.test(datePart)) {
+    const parts = datePart.split(/[\/\-]/).map((seg) => seg.trim());
+    if (parts.length === 3) {
+      const [m, d, yRaw] = parts;
+      let year = Number(yRaw);
+      const month = Number(m);
+      const day = Number(d);
+      if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+      if (year < 100) year += year >= 70 ? 1900 : 2000;
+      const dt = new Date(year, month - 1, day);
+      if (Number.isNaN(dt.getTime())) return null;
+      return toYMD(dt);
+    }
+  }
+  const parsed = new Date(str);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return toYMD(parsed);
+};
+
+export const compareYMD = (a, b) => String(a || "").localeCompare(String(b || ""));
+
+export const monthsBetween = (prev, next) => {
+  if (!prev || !next) return 0;
+  const months = (next.getFullYear() - prev.getFullYear()) * 12 + (next.getMonth() - prev.getMonth());
+  return Math.max(0, months);
+};
+
+export const todayYMD = (() => {
+  const d = new Date();
+  return toYMD(d);
+})();
+
+const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export const getDOWLabel = (value) => {
+  const n = Number(value);
+  if (Number.isNaN(n)) return DOW_LABELS[0];
+  const idx = ((n % 7) + 7) % 7;
+  return DOW_LABELS[idx] ?? DOW_LABELS[0];
+};
+
+export const normalizeNth = (value) => {
+  if (value === null || value === undefined) return "1";
+  if (typeof value === "string") {
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed === "last") return "last";
+    const parsed = parseInt(trimmed, 10);
+    if (Number.isFinite(parsed) && parsed >= 1 && parsed <= 5) return String(parsed);
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const int = Math.trunc(value);
+    if (int >= 1 && int <= 5) return String(int);
+  }
+  return "1";
+};
+
+export const ordinal = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "";
+  const mod100 = num % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${num}th`;
+  switch (num % 10) {
+    case 1:
+      return `${num}st`;
+    case 2:
+      return `${num}nd`;
+    case 3:
+      return `${num}rd`;
+    default:
+      return `${num}th`;
+  }
+};
+
+export const describeNth = (nth) => {
+  const n = normalizeNth(nth);
+  return n === "last" ? "last" : ordinal(Number(n));
+};
+
+export const toWeekdayArray = (value) => {
+  if (value === undefined || value === null) return [];
+
+  let raw;
+  if (Array.isArray(value)) raw = value;
+  else if (typeof value === "string" && value.includes(",")) raw = value.split(/[\s,]+/);
+  else raw = [value];
+
+  const seen = new Set();
+  const days = [];
+  for (const item of raw) {
+    if (item === undefined || item === null) continue;
+    const str = String(item).trim();
+    if (!str) continue;
+    const num = Number(str);
+    if (!Number.isFinite(num)) continue;
+    const normalized = Math.max(0, Math.min(6, Math.trunc(num)));
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      days.push(normalized);
+    }
+  }
+
+  return days.sort((a, b) => a - b);
+};
+
+export const firstWeekday = (value, fallback = 0) => {
+  const days = toWeekdayArray(value);
+  if (days.length) return days[0];
+  const num = Number(value);
+  if (Number.isFinite(num)) return Math.max(0, Math.min(6, Math.trunc(num)));
+  return Math.max(0, Math.min(6, Number(fallback) || 0));
+};
+
+export const formatWeekdayList = (value) => {
+  const days = toWeekdayArray(value);
+  if (!days.length) return "";
+  return days.map((dow) => getDOWLabel(dow)).join(", ");
+};
+
+export const readWeekdaySelections = (selectEl) => {
+  if (!selectEl) return [];
+  const values = Array.from(selectEl.selectedOptions || []).map((opt) => opt.value);
+  return toWeekdayArray(values);
+};

--- a/utils/formatting.js
+++ b/utils/formatting.js
@@ -1,0 +1,108 @@
+import { fromYMD } from "./dates.js";
+
+export const fmtMoney = (n) =>
+  (n < 0 ? "-$" : "$") + Math.abs(n).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+export const fmtDate = (ymd) => {
+  if (!ymd) return "";
+  try {
+    const d = fromYMD(ymd);
+    if (!(d instanceof Date) || Number.isNaN(d.getTime())) return ymd;
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  } catch (err) {
+    return ymd;
+  }
+};
+
+export const escapeHtml = (value) =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+export const round2 = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  return Math.round(num * 100) / 100;
+};
+
+export const fmtCount = (value) => {
+  const num = Number(value || 0);
+  return Number.isFinite(num) ? num.toLocaleString() : "0";
+};
+
+export const parseCurrency = (value) => {
+  if (value === null || value === undefined || value === "") return NaN;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : NaN;
+  }
+  let str = String(value).trim();
+  if (!str) return NaN;
+  let negative = false;
+  if (/^\((.*)\)$/.test(str)) {
+    negative = true;
+    str = str.slice(1, -1);
+  }
+  str = str.replace(/[−–—]/g, "-");
+  if (str.endsWith("-")) {
+    negative = true;
+    str = str.slice(0, -1);
+  }
+  if (str.startsWith("-")) {
+    negative = true;
+    str = str.slice(1);
+  }
+  str = str.replace(/[^0-9.,]/g, "");
+  if (!str) return NaN;
+  const hasComma = str.includes(",");
+  const hasDot = str.includes(".");
+  if (hasComma && hasDot) {
+    if (str.lastIndexOf(",") > str.lastIndexOf(".")) {
+      str = str.replace(/\./g, "");
+      str = str.replace(/,/g, ".");
+    } else {
+      str = str.replace(/,/g, "");
+    }
+  } else if (hasComma) {
+    const parts = str.split(",");
+    if (parts.length > 1 && parts[parts.length - 1].length === 2) {
+      str = parts.slice(0, -1).join("") + "." + parts[parts.length - 1];
+    } else {
+      str = parts.join("");
+    }
+  } else {
+    str = str.replace(/,/g, "");
+  }
+  const num = Number(str);
+  if (!Number.isFinite(num)) return NaN;
+  return negative ? -num : num;
+};
+
+export const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+
+export const compareText = (a, b) =>
+  String(a ?? "").localeCompare(String(b ?? ""), undefined, { sensitivity: "base" }) ||
+  String(a ?? "").localeCompare(String(b ?? ""));
+
+export const describeNameAndCategory = (entry, fallback) => {
+  if (!entry || typeof entry !== "object") return fallback;
+  const parts = [];
+  if (entry.name) parts.push(entry.name);
+  if (entry.category) parts.push(entry.category);
+  if (!parts.length && entry.note) parts.push(entry.note);
+  return parts.join(" – ") || fallback;
+};
+
+export const uid = () => Math.random().toString(36).slice(2, 9);
+
+export const deepClone = (value) => {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- extract date and formatting helpers into dedicated utils modules and migrate state management logic into a shared module
- move dashboard and what-if rendering into component modules and wire them into the main app
- switch the entry script to an ES module and replace hard-coded storage keys and default dates with shared constants

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd2e30a480832b9f8212cf6547ce08